### PR TITLE
fix: remove unsupported report variables argument

### DIFF
--- a/tofupilot/client.py
+++ b/tofupilot/client.py
@@ -74,7 +74,6 @@ class TofuPilotClient:
         started_at: Optional[datetime] = None,
         duration: Optional[timedelta] = None,
         sub_units: Optional[List[SubUnit]] = None,
-        report_variables: Optional[Dict[str, str]] = None,
         attachments: Optional[List[str]] = None,
     ) -> dict:
         """
@@ -99,8 +98,6 @@ class TofuPilotClient:
                 [A list of steps included in the test run](https://tofupilot.com/docs/steps). Default is None.
             sub_units (Optional[List[SubUnit]], optional):
                 [A list of sub-units included in the test run](https://tofupilot.com/docs/sub-units). Default is None.
-            report_variables (Optional[Dict[str, str]], optional):
-                [A dictionary of key values that will replace the procedure's {{report_variables}}](https://tofupilot.com/docs/report). Default is None.
             attachments (Optional[List[str]], optional):
                 [A list of file paths for attachments to include with the test run](https://tofupilot.com/docs/attachments). Default is None.
 
@@ -147,9 +144,6 @@ class TofuPilotClient:
 
         if sub_units is not None:
             payload["sub_units"] = sub_units
-
-        if report_variables is not None:
-            payload["report_variables"] = report_variables
 
         self._log_request("POST", "/runs", payload)
 

--- a/tofupilot/plugin.py
+++ b/tofupilot/plugin.py
@@ -22,7 +22,6 @@ class Conf:
         self.procedure_id: Optional[str] = None
         self.unit_under_test: Dict[str, Any] = {}
         self.sub_units: Optional[List[SubUnit]] = None
-        self.report_variables: Optional[Dict[str, str]] = None
         self.attachments: Optional[List[str]] = None
 
     def set(
@@ -33,7 +32,6 @@ class Conf:
         revision: Optional[str] = None,
         batch_number: Optional[str] = None,
         sub_units: Optional[List[SubUnit]] = None,
-        report_variables: Optional[Dict[str, str]] = None,
         attachments: Optional[List[str]] = None,
     ) -> None:
         if procedure_id is not None:
@@ -48,8 +46,6 @@ class Conf:
             self.unit_under_test["batch_number"] = batch_number
         if sub_units is not None:
             self.sub_units = sub_units
-        if report_variables is not None:
-            self.report_variables = report_variables
         if attachments is not None:
             self.attachments = attachments
         return self
@@ -184,7 +180,6 @@ class TestPilotPlugin:
                 duration=duration_td,
                 steps=steps,
                 sub_units=conf.sub_units,
-                report_variables=conf.report_variables,
                 attachments=conf.attachments,
             )
         except Exception as e:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the public interface for initiating runs by removing a legacy reporting configuration option.
	- The setup now accepts an optional list of attachments instead of the previous reporting variables.
	- This change simplifies the process of preparing and submitting reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->